### PR TITLE
Allow external images

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-source-strapi",
-  "version": "0.0.3",
+  "version": "0.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/normalize.js
+++ b/src/normalize.js
@@ -38,7 +38,9 @@ const extractFields = async (
         if (!fileNodeID) {
           try {
             // full media url
-            const source_url = apiURL + field.url
+            const source_url = `${field.url.startsWith('http') ? '' : apiURL}${
+              field.url
+            }`
             const fileNode = await createRemoteFileNode({
               url: source_url,
               store,


### PR DESCRIPTION
Stop prefixing the image URLs with apiURL if the url starts with "http". Useful if the images are stored in a storage service (eg. AWS S3, Cloudinary, etc.)