### PR TITLE
Switch to Gatsby's official terminal reporter and Fix #7 #52

### DIFF
--- a/src/fetch.js
+++ b/src/fetch.js
@@ -4,8 +4,8 @@ import pluralize from 'pluralize'
 
 module.exports = async ({ apiURL, contentType, jwtToken, queryLimit, reporter }) => {
   // Define API endpoint.
-  const apiBase = `${apiURL}/${pluralize(contentType)}`,
-        apiEndpoint = `${apiBase}?_limit=${queryLimit}`
+  const apiBase = `${apiURL}/${pluralize(contentType)}`
+  const apiEndpoint = `${apiBase}?_limit=${queryLimit}`
 
   reporter.info(`Starting to fetch data from Strapi - ${apiBase}`)
 

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -2,12 +2,12 @@ import axios from 'axios'
 import { isObject, startsWith, forEach } from 'lodash'
 import pluralize from 'pluralize'
 
-module.exports = async ({ apiURL, contentType, jwtToken, queryLimit }) => {
-  console.time('Fetch Strapi data')
-  console.log(`Starting to fetch data from Strapi (${pluralize(contentType)})`)
-
+module.exports = async ({ apiURL, contentType, jwtToken, queryLimit, reporter }) => {
   // Define API endpoint.
-  const apiEndpoint = `${apiURL}/${pluralize(contentType)}?_limit=${queryLimit}`
+  const apiBase = `${apiURL}/${pluralize(contentType)}`,
+        apiEndpoint = `${apiBase}?_limit=${queryLimit}`
+
+  reporter.info(`Starting to fetch data from Strapi - ${apiBase}`)
 
   // Set authorization token
   let fetchRequestConfig = {}
@@ -19,9 +19,6 @@ module.exports = async ({ apiURL, contentType, jwtToken, queryLimit }) => {
 
   // Make API request.
   const documents = await axios(apiEndpoint, fetchRequestConfig)
-
-  // Query all documents from client.
-  console.timeEnd('Fetch Strapi data')
 
   // Map and clean data.
   return documents.data.map(item => clean(item))

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -57,7 +57,7 @@ exports.sourceNodes = async (
     })
   )
 
-   // Execute the promises.
+  // Execute the promises.
   let entities = await Promise.all(promises)
 
   entities = await normalize.downloadMediaFiles({

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -5,7 +5,7 @@ import { capitalize } from 'lodash'
 import normalize from './normalize'
 
 exports.sourceNodes = async (
-  { store, boundActionCreators, cache },
+  { store, boundActionCreators, cache, reporter },
   {
     apiURL = 'http://localhost:1337',
     contentTypes = [],
@@ -23,8 +23,8 @@ exports.sourceNodes = async (
     loginData.hasOwnProperty('password') &&
     loginData.password.length !== 0
   ) {
-    console.time('Authenticate Strapi user')
-    console.log('Authenticate Strapi user')
+    const authenticationActivity = reporter.activityTimer(`Authenticate Strapi User`)
+    authenticationActivity.start()
 
     // Define API endpoint.
     const loginEndpoint = `${apiURL}/auth/local`
@@ -37,11 +37,14 @@ exports.sourceNodes = async (
         jwtToken = loginResponse.data.jwt
       }
     } catch (e) {
-      console.error('Strapi authentication error: ' + e)
+      reporter.panic('Strapi authentication error: ' + e)
     }
 
-    console.timeEnd('Authenticate Strapi user')
+    authenticationActivity.end()
   }
+
+  const fetchActivity = reporter.activityTimer(`Fetched Strapi Data`)
+  fetchActivity.start()
 
   // Generate a list of promises based on the `contentTypes` option.
   const promises = contentTypes.map(contentType =>
@@ -50,10 +53,11 @@ exports.sourceNodes = async (
       contentType,
       jwtToken,
       queryLimit,
+      reporter
     })
   )
 
-  // Execute the promises.
+   // Execute the promises.
   let entities = await Promise.all(promises)
 
   entities = await normalize.downloadMediaFiles({
@@ -73,4 +77,6 @@ exports.sourceNodes = async (
       createNode(node)
     })
   })
+
+  fetchActivity.end()
 }


### PR DESCRIPTION
# What does this pull request do?
1. Removes `Warning: No such label 'Fetch Strapi data' for console.timeEnd()` Errors from the terminal. More info here #7 #52
2. Tracks the elapsed time using gatsby's [`reporter.activityTimer`](https://github.com/gatsbyjs/gatsby/blob/370fdb42108e1d16b2de512f15e9e420baf8e4e8/packages/gatsby-cli/src/reporter/index.js#L87-L102) instead of a plain `console.time`
3. Handles errors with gatsby's [`reporter.panic`](https://github.com/gatsbyjs/gatsby/blob/370fdb42108e1d16b2de512f15e9e420baf8e4e8/packages/gatsby-cli/src/reporter/index.js#L46-L50) instead of a plain `console.error`
3. Prints messages using gatsby's [`reporter.info`](https://github.com/gatsbyjs/gatsby/blob/370fdb42108e1d16b2de512f15e9e420baf8e4e8/packages/gatsby-cli/src/reporter/index.js#L78) instead of a plain `console.log`

<h1 align="center">DEMO</h1>

# Before
![before](https://user-images.githubusercontent.com/5230079/56810201-5ed83700-683e-11e9-813b-5499777b70f5.png)

# After 
![after](https://user-images.githubusercontent.com/5230079/56810212-64ce1800-683e-11e9-9b6e-f51c6e664ea5.png)
