### PR TITLE
Replaced deprecated boundActionCreators with actions

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -5,7 +5,7 @@ import { capitalize } from 'lodash'
 import normalize from './normalize'
 
 exports.sourceNodes = async (
-  { store, boundActionCreators, cache },
+  { store, actions, cache },
   {
     apiURL = 'http://localhost:1337',
     contentTypes = [],
@@ -13,7 +13,7 @@ exports.sourceNodes = async (
     queryLimit = 100,
   }
 ) => {
-  const { createNode, touchNode } = boundActionCreators
+  const { createNode, touchNode } = actions
   let jwtToken = null
 
   // Check if loginData is set.


### PR DESCRIPTION
Replaced `boundActionCreators` as per https://www.gatsbyjs.org/docs/migrating-from-v1-to-v2/#rename-boundactioncreators-to-actions, with `actions`.

This has been tested.

This is needed to remove the warning message:

```
boundActionCreators is deprecated. Please use actions instead. For migration instructions, see
https://gatsby.dev/boundActionCreators
```