### PR TITLE
Fix: File nodes are not created for multiple file fields

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "workbench.colorCustomizations": {
+    "tab.unfocusedActiveBorder": "#fff0"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-source-strapi",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-source-strapi",
-  "version": "0.0.9",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-source-strapi",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joshdcuneo/gatsby-source-strapi",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A fork of the official Gatsby source plugin for building websites using Strapi as a data source with some upgrades and fixes",
   "author": {
     "email": "hi@strapi.io",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "gatsby-source-strapi",
-  "version": "0.0.9",
-  "description": "Gatsby source plugin for building websites using Strapi as a data source",
+  "name": "@joshdcuneo/gatsby-source-strapi",
+  "version": "0.1.0",
+  "description": "A fork of the official Gatsby source plugin for building websites using Strapi as a data source with some upgrades and fixes",
   "author": {
     "email": "hi@strapi.io",
     "name": "Strapi Solutions",
@@ -9,20 +9,18 @@
   },
   "maintainers": [
     {
-      "name": "Strapi Solutions",
-      "email": "hi@strapi.io",
-      "url": "http://strapi.io"
+      "name": "Josh Cuneo",
+      "email": "joshdcuneo@gmail.com"
     }
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/gatsby-source-strapi.git"
+    "url": "git://github.com/joshdcuneo/gatsby-source-strapi.git"
   },
   "bugs": {
-    "url": "https://github.com/strapi/gatsby-source-strapi/issues"
+    "url": "https://github.com/joshdcuneo/gatsby-source-strapi/issues"
   },
   "license": "MIT",
-  "homepage": "http://strapi.io",
   "scripts": {
     "prepublish": "npm run build",
     "build": "babel src --out-dir .",

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -3,7 +3,8 @@ import { isObject, startsWith, forEach } from 'lodash'
 import pluralize from 'pluralize'
 
 module.exports = async ({ apiURL, contentType, jwtToken, queryLimit }) => {
-  console.time('Fetch Strapi data')
+  const timer = `Fetch Strapi data for ${pluralize(contentType)}`
+  console.time(timer)
   console.log(`Starting to fetch data from Strapi (${pluralize(contentType)})`)
 
   // Define API endpoint.
@@ -21,7 +22,7 @@ module.exports = async ({ apiURL, contentType, jwtToken, queryLimit }) => {
   const documents = await axios(apiEndpoint, fetchRequestConfig)
 
   // Query all documents from client.
-  console.timeEnd('Fetch Strapi data')
+  console.timeEnd(timer)
 
   // Map and clean data.
   return documents.data.map(item => clean(item))

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -2,13 +2,19 @@ import axios from 'axios'
 import { isObject, startsWith, forEach } from 'lodash'
 import pluralize from 'pluralize'
 
-module.exports = async ({ apiURL, contentType, jwtToken, queryLimit }) => {
+module.exports = async ({
+  apiURL,
+  contentType,
+  jwtToken,
+  queryLimit,
+  reporter,
+}) => {
   const timer = `Fetch Strapi data for ${pluralize(contentType)}`
-  console.time(timer)
-  console.log(`Starting to fetch data from Strapi (${pluralize(contentType)})`)
 
-  // Define API endpoint.
-  const apiEndpoint = `${apiURL}/${pluralize(contentType)}?_limit=${queryLimit}`
+  const apiBase = `${apiURL}/${pluralize(contentType)}`,
+    apiEndpoint = `${apiBase}?_limit=${queryLimit}`
+
+  reporter.info(`Starting to fetch data from Strapi - ${apiBase}`)
 
   // Set authorization token
   let fetchRequestConfig = {}
@@ -20,9 +26,6 @@ module.exports = async ({ apiURL, contentType, jwtToken, queryLimit }) => {
 
   // Make API request.
   const documents = await axios(apiEndpoint, fetchRequestConfig)
-
-  // Query all documents from client.
-  console.timeEnd(timer)
 
   // Map and clean data.
   return documents.data.map(item => clean(item))


### PR DESCRIPTION
Hi,

Thanks for your work on this plugin. 

Just opening a PR to address [this issue](https://github.com/strapi/gatsby-source-strapi/issues/79).

Fields with arrays of files were not handled correctly in extractFields resulting in file nodes not being generated. This PR should resolve that as well as some console.time calls with duplicate identifiers.

Let me know if you need anything to get it merged.

Josh