### PR TITLE
Bugfix: deep media fields are not parsed

### DIFF
--- a/src/normalize.js
+++ b/src/normalize.js
@@ -65,6 +65,8 @@ const extractFields = async (
         if (fileNodeID) {
           item[`${key}___NODE`] = fileNodeID
         }
+      } else if (field !== null && typeof field === 'object') {
+        extractFields(apiURL, store, cache, createNode, touchNode, auth, field);
       }
     }
   }


### PR DESCRIPTION
The commit fixes the issue when deep media fields are not parsed.

E.g. :
```js
const post = {
  id: 1,
  cover: {
    // strapi image fields go here
  },
  author: {
    username: 'Joe',
    image: {
      // strapi image fields go here
    }
  }
}
```

There `post.cover` is parsed and added as GraphQL Type, but `post.user.image` is not parsed.