### PR TITLE
Allow child image sharp on arrays of images

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,25 @@ You can query Document nodes created from your Strapi API like the following:
   }
 }
 ```
+
+To query images you can do the following:
+
+```graphql
+{
+  allStrapiArticle {
+    edges {
+      node {
+        id
+        singleImage {
+         publicURL
+        }
+        multipleImages {
+          localFile {
+            publicURL
+          }
+        }
+      }
+    }
+  }
+}
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-source-strapi",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Gatsby source plugin for building websites using Strapi as a data source",
   "author": {
     "email": "hi@strapi.io",

--- a/src/normalize.js
+++ b/src/normalize.js
@@ -13,7 +13,7 @@ const extractFields = async (
 ) => {
   // image fields have a mime property among other
   // maybe should find a better test
-  if(item && item.hasOwnProperty('mime')) {
+  if (item && item.hasOwnProperty('mime')) {
     let fileNodeID
     // using field on the cache key for multiple image field
     const mediaDataCacheKey = `strapi-media-${item.id}-${key}`
@@ -32,7 +32,7 @@ const extractFields = async (
         // full media url
         const source_url = `${item.url.startsWith('http') ? '' : apiURL}${
           item.url
-          }`
+        }`
         const fileNode = await createRemoteFileNode({
           url: source_url,
           store,
@@ -57,13 +57,13 @@ const extractFields = async (
     }
 
     if (fileNodeID) {
-      if(key === 'localFile') {
-        item[`${key}___NODE`] = fileNodeID
+      if (key !== 'localFile') {
+        return fileNodeID
       }
 
-      return fileNodeID
+      item.localFile___NODE = fileNodeID
     }
-  } else if(Array.isArray(item)) {
+  } else if (Array.isArray(item)) {
     await Promise.all(
       item.map(async f =>
         extractFields(
@@ -78,8 +78,8 @@ const extractFields = async (
         )
       )
     )
-  } else if(item && typeof item === 'object') {
-    for(const key of Object.keys(item)) {
+  } else if (item && typeof item === 'object') {
+    for (const key of Object.keys(item)) {
       const field = item[key]
 
       const fileNodeID = await extractFields(

--- a/src/normalize.js
+++ b/src/normalize.js
@@ -48,7 +48,7 @@ const extractFields = async (
 
           await cache.set(mediaDataCacheKey, {
             fileNodeID,
-            modified: item.updatedAt,
+            updatedAt: item.updatedAt,
           })
         }
       } catch (e) {

--- a/src/normalize.js
+++ b/src/normalize.js
@@ -5,66 +5,97 @@ const extractFields = async (
   store,
   cache,
   createNode,
+  createNodeId,
   touchNode,
   auth,
-  item
+  item,
+  key = 'localFile'
 ) => {
-  for (const key of Object.keys(item)) {
-    const field = item[key]
-    if (Array.isArray(field)) {
-      // add recursion to fetch nested strapi references
-      await Promise.all(
-        field.map(async f =>
-          extractFields(apiURL, store, cache, createNode, touchNode, auth, f)
-        )
-      )
-    } else {
-      // image fields have a mime property among other
-      // maybe should find a better test
-      if (field !== null && field.hasOwnProperty('mime')) {
-        let fileNodeID
-        // using field on the cache key for multiple image field
-        const mediaDataCacheKey = `strapi-media-${item.id}-${key}`
-        const cacheMediaData = await cache.get(mediaDataCacheKey)
+  // image fields have a mime property among other
+  // maybe should find a better test
+  if(item && item.hasOwnProperty('mime')) {
+    let fileNodeID
+    // using field on the cache key for multiple image field
+    const mediaDataCacheKey = `strapi-media-${item.id}-${key}`
+    const cacheMediaData = await cache.get(mediaDataCacheKey)
 
-        // If we have cached media data and it wasn't modified, reuse
-        // previously created file node to not try to redownload
-        if (cacheMediaData && field.updatedAt === cacheMediaData.updatedAt) {
-          fileNodeID = cacheMediaData.fileNodeID
-          touchNode({ nodeId: cacheMediaData.fileNodeID })
-        }
+    // If we have cached media data and it wasn't modified, reuse
+    // previously created file node to not try to redownload
+    if (cacheMediaData && item.updatedAt === cacheMediaData.updatedAt) {
+      fileNodeID = cacheMediaData.fileNodeID
+      touchNode({ nodeId: cacheMediaData.fileNodeID })
+    }
+
+    // If we don't have cached data, download the file
+    if (!fileNodeID) {
+      try {
+        // full media url
+        const source_url = `${item.url.startsWith('http') ? '' : apiURL}${
+          item.url
+          }`
+        const fileNode = await createRemoteFileNode({
+          url: source_url,
+          store,
+          cache,
+          createNode,
+          createNodeId,
+          auth,
+        })
 
         // If we don't have cached data, download the file
-        if (!fileNodeID) {
-          try {
-            // full media url
-            const source_url = `${field.url.startsWith('http') ? '' : apiURL}${
-              field.url
-            }`
-            const fileNode = await createRemoteFileNode({
-              url: source_url,
-              store,
-              cache,
-              createNode,
-              auth,
-            })
+        if (fileNode) {
+          fileNodeID = fileNode.id
 
-            // If we don't have cached data, download the file
-            if (fileNode) {
-              fileNodeID = fileNode.id
+          await cache.set(mediaDataCacheKey, {
+            fileNodeID,
+            modified: item.updatedAt,
+          })
+        }
+      } catch (e) {
+        // Ignore
+      }
+    }
 
-              await cache.set(mediaDataCacheKey, {
-                fileNodeID,
-                modified: field.updatedAt,
-              })
-            }
-          } catch (e) {
-            // Ignore
-          }
-        }
-        if (fileNodeID) {
-          item[`${key}___NODE`] = fileNodeID
-        }
+    if (fileNodeID) {
+      if(key === 'localFile') {
+        item[`${key}___NODE`] = fileNodeID
+      }
+
+      return fileNodeID
+    }
+  } else if(Array.isArray(item)) {
+    await Promise.all(
+      item.map(async f =>
+        extractFields(
+          apiURL,
+          store,
+          cache,
+          createNode,
+          createNodeId,
+          touchNode,
+          auth,
+          f
+        )
+      )
+    )
+  } else if(item && typeof item === 'object') {
+    for(const key of Object.keys(item)) {
+      const field = item[key]
+
+      const fileNodeID = await extractFields(
+        apiURL,
+        store,
+        cache,
+        createNode,
+        createNodeId,
+        touchNode,
+        auth,
+        field,
+        key
+      )
+
+      if (fileNodeID) {
+        item[`${key}___NODE`] = fileNodeID
       }
     }
   }
@@ -77,6 +108,7 @@ exports.downloadMediaFiles = async ({
   store,
   cache,
   createNode,
+  createNodeId,
   touchNode,
   jwtToken: auth,
 }) =>
@@ -89,6 +121,7 @@ exports.downloadMediaFiles = async ({
           store,
           cache,
           createNode,
+          createNodeId,
           touchNode,
           auth,
           item


### PR DESCRIPTION
Right now it's not possible to query File properties on arrays of images, for example this results in an error: 

```graphql
{
  allStrapiArticle {
    edges {
      node {
        multipleImages {
          publicURL
          childImageSharp {
            ...
          }
        }
      }
    }
  }
}
```

this pull request fixes the issue by allowing to query a localFile field on arrays of images:

```graphql
{
  allStrapiArticle {
    edges {
      node {
        multipleImages {
          localFile {
            publicURL
            childImageSharp {
               ...
            }
          }
        }
      }
    }
  }
}
```