### PR TITLE
Add support for images embedded in the markdown content

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -997,6 +997,24 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
       "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
     },
+    "commonmark": {
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/commonmark/-/commonmark-0.29.1.tgz",
+      "integrity": "sha512-DafPdNYFXoEhsSiR4O+dJ45UJBfDL4cBTks4B+agKiaWt7qjG0bIhg5xuCE0RqU71ikJcBIf4/sRHh9vYQVF8Q==",
+      "requires": {
+        "entities": "~1.1.1",
+        "mdurl": "~1.0.1",
+        "minimist": "~1.2.0",
+        "string.prototype.repeat": "^0.2.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+        }
+      }
+    },
     "component-emitter": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
@@ -1139,6 +1157,11 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.82.tgz",
       "integrity": "sha512-NI4nB2IWGcU4JVT1AE8kBb/dFor4zjLHMLsOROPahppeHrR0FG5uslxMmkp/thO1MvPjM2xhlKoY29/I60s0ew==",
       "dev": true
+    },
+    "entities": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -2207,6 +2230,11 @@
         "buffer-alloc": "^1.1.0"
       }
     },
+    "mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
+    },
     "micromatch": {
       "version": "2.3.11",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
@@ -3182,6 +3210,11 @@
           }
         }
       }
+    },
+    "string.prototype.repeat": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-0.2.0.tgz",
+      "integrity": "sha1-q6Nt4I3O5qWjN9SbLqHaGyj8Ds8="
     },
     "string_decoder": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   ],
   "dependencies": {
     "axios": "^0.18.0",
+    "commonmark": "^0.29.1",
     "gatsby-node-helpers": "^0.3.0",
     "gatsby-source-filesystem": "^1.5.39",
     "lodash": "^4.17.11",

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -13,6 +13,7 @@ exports.sourceNodes = async (
     singleTypes = [],
     loginData = {},
     queryLimit = 100,
+    markdownImages = {},
   }
 ) => {
   const { createNode, deleteNode, touchNode } = actions
@@ -61,6 +62,10 @@ exports.sourceNodes = async (
     createNode,
     touchNode,
     jwtToken,
+    options: {
+      allTypes: contentTypes.concat(singleTypes),
+      markdownImages,
+    },
   })
 
   // new created nodes


### PR DESCRIPTION
This PR includes an idea to solve the gap in image processing. When we use rich content including images those images are not downloaded and not processed by Gatsby during the build. Instead their URLs are untouched and if they are uploaded on the local instance of Strapi (/uploads folder) there is no way to display them on the final static page. 

The idea is to:
* allow configuration to specify if and which fields should be parsed for images
* extract images paths and create remote file node for each of them
* put all the newly created nodes as an array to new field (e.g. if the parsed field name is `content` the images would go to `content_images`
* replace original image's paths with newly created file node's base paths (that will allow us to later for e.g. use gatsby-image)

With that all the files will be copied to Gatsby app.

Proposed configuration could look like this:
```
{
      resolve: 'gatsby-source-strapi',
      options: {
        apiURL: 'http://localhost:1337',
        contentTypes: ['post', 'post-category'],
        queryLimit: 1000,
        markdownImages: {
          typesToParse: {
            post: ['content']  // here we specify that we only want to parse "content" field on "post" content-type
          }
        }
      }
    }
```

We're currently using this in our project and it works just fine. 
In our case we're replacing all the images from the markdown with `gatsby-image`, like this (not a real code):

```
<ReactMarkdown
      source={content}
      renderers={{
        image: ({ src, alt }) => {
          const image = getImage(src); //  this helper function will find an image from Gatsby's GraphQL query that has the same `base` property as found image `src`

          return <Img fixed={image.childImageSharp.fixed} alt={alt} />               
        }
      }}
    />
```


Thought it may be useful.
#114 


