### PR TITLE
add support for irregular collection names

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,14 @@ plugins: [
     options: {
       apiURL: `http://localhost:1337`,
       queryLimit: 1000, // Default to 100
-      contentTypes: [`article`, `user`],
+      contentTypes: [
+        `article`, `user`,
+        //for irregular collection names
+        {
+          name: `person`,
+          plural: `people`
+        },
+      ],
       //If using single types place them in this array.
       singleTypes: [`home-page`, `contact`],
       // Possibility to login with a strapi user, when content types are not publically available (optional).

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ plugins: [
       queryLimit: 1000, // Default to 100
       contentTypes: [
         `article`, `user`,
-        //for irregular collection names
+        // if you don't want to leave the definition of an api endpoint to the pluralize module
         {
-          name: `person`,
-          plural: `people`
+          name: `collection-name`,
+          endpoint: `custom-endpoint`
         },
       ],
       //If using single types place them in this array.

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -4,8 +4,8 @@ import pluralize from 'pluralize'
 
 module.exports = async ({ apiURL, contentType, singleType, jwtToken, queryLimit, reporter }) => {
   // Define API endpoint.
-  let pluralizedContentType = contentType && contentType.plural
-    ? contentType.plural
+  let pluralizedContentType = contentType && contentType.endpoint
+    ? contentType.endpoint
     : contentType
       ? pluralize(contentType)
       : undefined;

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -11,9 +11,14 @@ module.exports = async ({
   reporter,
 }) => {
   // Define API endpoint.
+  let pluralizedContentType = contentType && contentType.plural
+    ? contentType.plural
+    : contentType
+      ? pluralize(contentType)
+      : undefined;
   let apiBase = singleType
     ? `${apiURL}/${singleType}`
-    : `${apiURL}/${pluralize(contentType)}`
+    : `${apiURL}/${pluralizedContentType}`
 
   const apiEndpoint = `${apiBase}?_limit=${queryLimit}`
 

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -80,7 +80,9 @@ exports.sourceNodes = async (
   contentTypes.concat(singleTypes).forEach((contentType, i) => {
     const items = entities[i]
     items.forEach((item, i) => {
-      const node = Node(capitalize(contentType), item)
+      const node = contentType.name
+                  ?  Node(capitalize(contentType.name), item) 
+                  :  Node(capitalize(contentType), item)
       // Adding new created nodes in an Array
       newNodes.push(node)
 


### PR DESCRIPTION
this is to add the option to have **collection names with irregular plurals** (such as person -> people) which occurs quite often in other languages (e. g. in German Person -> Personen).
Adding contentTypes with irregular plurals along regular ones can be done like this in gatsby-config.js:

```
contentTypes: [
        `article`, `user`,
        //for irregular collection names
        {
          name: `person`,
          plural: `people`
        }
      ],
```

I am using it and it is working.

as mentioned in [issue #113 ](https://github.com/strapi/gatsby-source-strapi/issues/113)
