### PR TITLE
Fix query images data from component field

### DIFF
--- a/src/normalize.js
+++ b/src/normalize.js
@@ -15,7 +15,7 @@ const extractFields = async (
       // add recursion to fetch nested strapi references
       await Promise.all(
         field.map(async f =>
-          await extractFields(apiURL, store, cache, createNode, touchNode, auth, f)
+          extractFields(apiURL, store, cache, createNode, touchNode, auth, f)
         )
       )
     } else {

--- a/src/normalize.js
+++ b/src/normalize.js
@@ -15,7 +15,7 @@ const extractFields = async (
       // add recursion to fetch nested strapi references
       await Promise.all(
         field.map(async f =>
-          extractFields(apiURL, store, cache, createNode, touchNode, auth, f)
+          await extractFields(apiURL, store, cache, createNode, touchNode, auth, f)
         )
       )
     } else {
@@ -66,7 +66,7 @@ const extractFields = async (
           item[`${key}___NODE`] = fileNodeID
         }
       } else if (field !== null && typeof field === 'object') {
-        extractFields(apiURL, store, cache, createNode, touchNode, auth, field)
+        await extractFields(apiURL, store, cache, createNode, touchNode, auth, field)
       }
     }
   }


### PR DESCRIPTION
This PR fixes issue with getting images data from component field. 

In my project I am using collection ```posts``` with configuration:

```javascript
{
  "kind": "collectionType",
  "collectionName": "posts",
  "info": {
    "name": "Post"
  },
  "options": {
    "increments": true,
    "timestamps": true
  },
  "attributes": {
    "title": {
      "type": "string",
      "required": true
    },
    "cover": {
      "type": "component",
      "repeatable": false,
      "component": "post.cover"
    }
  }
}
```

And ```cover``` component definition:

```javascript
{
  "collectionName": "components_post_covers",
  "info": {
    "name": "Cover",
    "icon": "book"
  },
  "options": {},
  "attributes": {
    "cover_image": {
      "model": "file",
      "via": "related",
      "allowedTypes": [
        "images"
      ],
      "plugin": "upload",
      "required": true
    },
    "cover_background": {
      "model": "background"
    }
  }
}
```

In my case, using more than 3 posts was causing issue with missing cover images data.

Using ```await``` to fetch nasted strapi references fixes this issue.