### PR TITLE
Updates package.json to resolve DeprecationWarning Error on Node12

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "axios": "^0.18.0",
     "gatsby-node-helpers": "^0.3.0",
-    "gatsby-source-filesystem": "^1.5.39",
+    "gatsby-source-filesystem": "^2.3.14",
     "lodash": "^4.17.11",
     "pluralize": "^7.0.0"
   },


### PR DESCRIPTION
Bumps gatsby-source-filesystem to "^2.3.14" to avoid Node 12 Error:

(node:43092) [DEP0066] DeprecationWarning: OutgoingMessage.prototype._headers is deprecated

Addresses these issues within Gatsby, but its also a STDERR which can cause some pipelines to fail:
https://github.com/gatsbyjs/gatsby/issues/25427
https://github.com/gatsbyjs/gatsby/issues/20529
https://github.com/gatsbyjs/gatsby/issues/18433
