### PR TITLE
DEP0066 Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "axios": "^0.18.0",
     "gatsby-node-helpers": "^0.3.0",
-    "gatsby-source-filesystem": "^1.5.39",
+    "gatsby-source-filesystem": "^2.3.14",
     "lodash": "^4.17.11",
     "pluralize": "^7.0.0"
   },


### PR DESCRIPTION
Fixes deprecation error that comes from gatsby-source-filesystem dep 