### PR TITLE
Add query string to type definition (gatsby-config.js) in order to handle i18n

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,17 @@ plugins: [
           name: `collection-name`,
           endpoint: `custom-endpoint`,
         },
+        // if you want to use custom query strings (e.g. to fetch all locales)
+        // mapping of api.qs object will be used to create final query string (e.g: http://localhost:1337/collection-name?_locale=all)
+        {
+          name: `collection-name`,
+          api: { qs: { _locale: 'all' } }
+        },
+        // exemple fetching only english content
+        {
+          name: `collection-name`,
+          api: { qs: { _locale: 'en' } }
+        },
       ],
       //If using single types place them in this array.
       singleTypes: [`home-page`, `contact`],
@@ -57,6 +68,23 @@ You can query Document nodes created from your Strapi API like the following:
   }
 }
 ```
+
+You can query Document nodes in chosen language
+> make sure to add `api.qs._locale` to your strapi conf in `gatsby-config.js` (see example above)
+```graphql
+{
+  allStrapiArticle(filter: { locale: "en" }) {
+    edges {
+      node {
+        id
+        title
+        content
+      }
+    }
+  }
+}
+```
+
 
 To query images you can do the following:
 

--- a/README.md
+++ b/README.md
@@ -69,8 +69,10 @@ You can query Document nodes created from your Strapi API like the following:
 }
 ```
 
-You can query Document nodes in chosen language
-> make sure to add `api.qs._locale` to your strapi conf in `gatsby-config.js` (see example above)
+You can query Document nodes in a chosen language
+
+Make sure to add `api.qs._locale` to your strapi configuration in `gatsby-config.js` (see example above)
+
 ```graphql
 {
   allStrapiArticle(filter: { locale: "en" }) {

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -6,13 +6,18 @@ module.exports = async (entityDefinition, ctx) => {
 
   const { endpoint, api } = entityDefinition;
 
+  // Place global params first, so that they can be overriden by api.qs
+  const params = { _limit: queryLimit, ...api?.qs };
+
   // Retrieve qs params if defined (or empty string instead)
-  const qs = api ? Object.keys(api.qs).map((param) => `&${param}=${api.qs[param]}`) : ``;
+  const qs = Object.keys(params)
+    .map((param) => `${param}=${params[param]}`)
+    .join('&');
 
   // Define API endpoint.
   let apiBase = `${apiURL}/${endpoint}`;
 
-  const apiEndpoint = `${apiBase}?_limit=${queryLimit}${qs}`;
+  const apiEndpoint = `${apiBase}?${qs}`;
 
   reporter.info(`Starting to fetch data from Strapi - ${apiEndpoint}`);
 

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -1,13 +1,18 @@
 import axios from 'axios';
 import { isObject, forEach, set, castArray, startsWith } from 'lodash';
 
-module.exports = async (endpoint, ctx) => {
+module.exports = async (entityDefinition, ctx) => {
   const { apiURL, queryLimit, jwtToken, reporter } = ctx;
+
+  const { endpoint, api } = entityDefinition;
+
+  // Retrieve qs params if defined (or empty string instead)
+  const qs = api ? Object.keys(api.qs).map((param) => `&${param}=${api.qs[param]}`) : ``;
 
   // Define API endpoint.
   let apiBase = `${apiURL}/${endpoint}`;
 
-  const apiEndpoint = `${apiBase}?_limit=${queryLimit}`;
+  const apiEndpoint = `${apiBase}?_limit=${queryLimit}${qs}`;
 
   reporter.info(`Starting to fetch data from Strapi - ${apiEndpoint}`);
 

--- a/src/index.js
+++ b/src/index.js
@@ -7,8 +7,12 @@ import normalize from './normalize';
 import authentication from './authentication';
 
 const toTypeInfo = (type, { single = false }) => {
-  if (type.endpoint) {
-    return { endpoint: type.endpoint, name: type.name };
+  if (typeof type === 'object') {
+    return {
+      endpoint: type.endpoint || type.name,
+      name: type.name,
+      api: type.api,
+    };
   }
 
   return { endpoint: single ? type : pluralize(type), name: type };
@@ -17,8 +21,8 @@ const toTypeInfo = (type, { single = false }) => {
 const contentTypeToTypeInfo = toTypeInfo;
 const singleTypeToTypeInfo = (singleType) => toTypeInfo(singleType, { single: true });
 
-const fetchEntities = async ({ endpoint }, ctx) => {
-  const entities = await fetchData(endpoint, ctx);
+const fetchEntities = async (entityDefinition, ctx) => {
+  const entities = await fetchData(entityDefinition, ctx);
   await normalize.downloadMediaFiles(entities, ctx);
 
   return entities;

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ import authentication from './authentication';
 const toTypeInfo = (type, { single = false }) => {
   if (typeof type === 'object') {
     return {
-      endpoint: type.endpoint || type.name,
+      endpoint: type.endpoint || (single ? type.name : pluralize(type.name)),
       name: type.name,
       api: type.api,
     };


### PR DESCRIPTION
@alexandrebodin there we go, I applied your idea that was indeed the best way to handle this problem.

I've updated README accordingly.

I've also added `queryLimit` param to this new behavior. It can now be overriden individually for each type.