### PR TITLE
Rename contentTypes to collectionTypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,24 +21,24 @@ plugins: [
       collectionTypes: [
         `article`,
         `user`,
-        // If you don't want to leave the definition of an api endpoint to the pluralize module
+        // if you don't want to leave the definition of an api endpoint to the pluralize module
         {
           name: `collection-name`,
           endpoint: `custom-endpoint`,
         },
-        // If you want to use custom query strings (e.g. to fetch all locales)
-        // Mapping of api.qs object will be used to create final query string (e.g: http://localhost:1337/collection-name?_locale=all)
+        // if you want to use custom query strings (e.g. to fetch all locales)
+        // mapping of api.qs object will be used to create final query string (e.g: http://localhost:1337/collection-name?_locale=all)
         {
           name: `collection-name`,
           api: { qs: { _locale: 'all' } }
         },
-        // Example fetching only english content
+        // exemple fetching only english content
         {
           name: `collection-name`,
           api: { qs: { _locale: 'en' } }
         },
       ],
-      // If using single types place them in this array.
+      //If using single types place them in this array.
       singleTypes: [`home-page`, `contact`],
       // Possibility to login with a strapi user, when content types are not publically available (optional).
       loginData: {

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 Source plugin for pulling documents into Gatsby from a Strapi API.
 
-
 > **WARNING**: This is the README for v1.0.0 which is in `alpha` version for now. Make sure to install it with @alpha to try it out. It's designed to be used with Gatsby v3.
 
 ## Install
@@ -19,27 +18,27 @@ plugins: [
     options: {
       apiURL: `http://localhost:1337`,
       queryLimit: 1000, // Default to 100
-      contentTypes: [
+      collectionTypes: [
         `article`,
         `user`,
-        // if you don't want to leave the definition of an api endpoint to the pluralize module
+        // If you don't want to leave the definition of an api endpoint to the pluralize module
         {
           name: `collection-name`,
           endpoint: `custom-endpoint`,
         },
-        // if you want to use custom query strings (e.g. to fetch all locales)
-        // mapping of api.qs object will be used to create final query string (e.g: http://localhost:1337/collection-name?_locale=all)
+        // If you want to use custom query strings (e.g. to fetch all locales)
+        // Mapping of api.qs object will be used to create final query string (e.g: http://localhost:1337/collection-name?_locale=all)
         {
           name: `collection-name`,
           api: { qs: { _locale: 'all' } }
         },
-        // exemple fetching only english content
+        // Example fetching only english content
         {
           name: `collection-name`,
           api: { qs: { _locale: 'en' } }
         },
       ],
-      //If using single types place them in this array.
+      // If using single types place them in this array.
       singleTypes: [`home-page`, `contact`],
       // Possibility to login with a strapi user, when content types are not publically available (optional).
       loginData: {

--- a/src/index.js
+++ b/src/index.js
@@ -83,13 +83,6 @@ exports.sourceNodes = async (
   const collectionTypes = (options.collectionTypes || []).map(contentTypeToTypeInfo);
   const singleTypes = (options.singleTypes || []).map(singleTypeToTypeInfo);
 
-  // Let users know that options.contentTypes is deprecated
-  if (options.contentTypes) {
-    reporter.warn(
-      'Passing `contentTypes` to the gatsby-source-strapi options is deprecated. Use `collectionTypes` instead'
-    );
-  }
-
   const types = [...collectionTypes, ...singleTypes];
 
   // Execute the promises

--- a/src/index.js
+++ b/src/index.js
@@ -80,10 +80,17 @@ exports.sourceNodes = async (
   const fetchActivity = reporter.activityTimer(`Fetched Strapi Data`);
   fetchActivity.start();
 
-  const contentTypes = (options.contentTypes || []).map(contentTypeToTypeInfo);
+  const collectionTypes = (options.collectionTypes || []).map(contentTypeToTypeInfo);
   const singleTypes = (options.singleTypes || []).map(singleTypeToTypeInfo);
 
-  const types = [...contentTypes, ...singleTypes];
+  // Let users know that options.contentTypes is deprecated
+  if (options.contentTypes) {
+    reporter.warn(
+      'Passing `contentTypes` to the gatsby-source-strapi options is deprecated. Use `collectionTypes` instead'
+    );
+  }
+
+  const types = [...collectionTypes, ...singleTypes];
 
   // Execute the promises
   const entities = await Promise.all(types.map((type) => fetchEntities(type, ctx)));
@@ -97,7 +104,7 @@ exports.sourceNodes = async (
   // Touch each one of them
   existingNodes.forEach((node) => touchNode(node));
 
-  // Merge single and content types and retrieve create nodes
+  // Merge single and collection types and retrieve create nodes
   types.forEach(({ name }, i) => {
     const items = entities[i];
 


### PR DESCRIPTION
The term "content types" in Strapi refers to both collection types and single types. So I renamed the options field to "collectionTypes" to avoid the confusion.

This will be a breaking change as users will need to modify their Gatsby config.