### PR TITLE
Allow fetching all items with multiple calls instead of a very large one

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,30 @@ plugins: [
 ];
 ```
 
+#### Multiple requests instead of a single large one
+
+If you have many items in a collection and a single API call is a bit heavy for your server, you can split it into multiple requests.
+
+```javascript
+// In your gatsby-config.js
+plugins: [
+  {
+    resolve: `gatsby-source-strapi`,
+    options: {
+      apiURL: `http://localhost:1337`,
+      collectionTypes: [
+        // Fetch all locales for collection-name
+        {
+          name: `collection-name`,
+          api: { qs: { _sort: 'drop_date:DESC' } }, 
+          loop: 100,
+        },
+      ]
+    },
+  },
+];
+```
+
 ## Querying data
 
 You can query Document nodes created from your Strapi API like the following:

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ plugins: [
 
 #### Multiple requests instead of a single large one
 
-If you have many items in a collection and a single API call is a bit heavy for your server, you can split it into multiple requests.
+When you have many items in a collection, a single API call can be a bit heavy for your server. In that case, you can split your data fetching into multiple requests.
 
 ```javascript
 // In your gatsby-config.js
@@ -156,8 +156,7 @@ plugins: [
         // Fetch all locales for collection-name
         {
           name: `collection-name`,
-          api: { qs: { _sort: 'drop_date:DESC' } }, 
-          loop: 100,
+          api: { qs: { _sort: 'drop_date:DESC' }, loop: 100, }, 
         },
       ]
     },

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ const toTypeInfo = (type, { single = false }) => {
   if (typeof type === 'object') {
     return {
       endpoint: type.endpoint || (single ? type.name : pluralize(type.name)),
+      loop: type.loop,
       name: type.name,
       api: type.api,
     };

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,6 @@ const toTypeInfo = (type, { single = false }) => {
   if (typeof type === 'object') {
     return {
       endpoint: type.endpoint || (single ? type.name : pluralize(type.name)),
-      loop: type.loop,
       name: type.name,
       api: type.api,
     };


### PR DESCRIPTION
Fix #104 

Especially usefull on servers limiting the duration of requests (for example Heroku, which limits to 30sec each request).

Passing the loop parameter will perform multiple calls until all items are downloaded.

Readme.md updated with an example.