### PR TITLE
Remove unnecessary files from npm releases

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -34,3 +34,6 @@ decls
 examples
 .idea
 .eslintcache
+.babelrc
+.eslintrc.js
+.prettierrc.js

--- a/.npmignore
+++ b/.npmignore
@@ -33,3 +33,4 @@ coverage
 decls
 examples
 .idea
+.eslintcache


### PR DESCRIPTION
This PR extends the `.npmignore` list by a few more files that should not be included in npm package.