### PR TITLE
Let gatsby-source-filesystem handle filenames

### DIFF
--- a/src/normalize.js
+++ b/src/normalize.js
@@ -31,8 +31,6 @@ const extractImage = async (image, ctx) => {
       createNode,
       createNodeId,
       auth,
-      ext: image.ext,
-      name: image.name,
     });
 
     if (fileNode) {


### PR DESCRIPTION
I noticed that image assets generated with `gatsby-source-strapi` have two extensions in the filename: original and target extension.

Input: `my_filename.jpg` (original image is JPG)
Output: `my_filename.jpg.png` (when querying PNG image)

There were two solutions for this:
1. Pass extension-less filename to `name`
2. Let `gatsby-source-filesystem` handle the name and extension retrieval

I went with the second solution as `gatsby-source-filesystem` handles special characters (spaces, brackets, etc.) out of the box, but also adds additonal file hash to the filename for better cache invalidation.