### PR TITLE
Allow hyphens in collectionTypes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import pluralize from 'pluralize';
-import _, { capitalize } from 'lodash';
+import _, { upperFirst, camelCase, capitalize } from 'lodash';
 
 import fetchData from './fetch';
 import { Node } from './nodes';
@@ -44,7 +44,7 @@ const addDynamicZoneFieldsToSchema = ({ type, items, actions, schema }) => {
   // Cast dynamic zone fields to JSON
   if (!_.isEmpty(dynamicZoneFields)) {
     const typeDef = schema.buildObjectType({
-      name: `Strapi${capitalize(type)}`,
+      name: `Strapi${upperFirst(camelCase(type))}`,
       fields: dynamicZoneFields,
       interfaces: ['Node'],
     });


### PR DESCRIPTION
Fix #197 

This change fixes the schema name conversion correctly even if the name contains a hyphen