### PR TITLE
Added missing main field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "directories": {
     "lib": "./lib"
   },
+  "main": "lib/index.js",
   "files": [
     "lib/*",
     "gatsby-node.js"


### PR DESCRIPTION
Hi.

When I run gatsby project (`gatsby develop`) which uses this plugin I get an error:

```
 ERROR #10226  CONFIG

Couldn't find the "gatsby-source-strapi" plugin declared in
"/home/piotr.roszatycki/Sources/gatsby/strapi-gatsby/packages/gatsby-theme-strapi/gatsby-config.js".

Tried looking for an installed package in the following paths:
 - /home/piotr.roszatycki/Sources/gatsby/strapi-gatsby/node_modules/gatsby/dist/bootstrap/load-themes/node_modules/gatsby-source-strapi
 - /home/piotr.roszatycki/Sources/gatsby/strapi-gatsby/node_modules/gatsby/dist/bootstrap/node_modules/gatsby-source-strapi
 - /home/piotr.roszatycki/Sources/gatsby/strapi-gatsby/node_modules/gatsby/dist/node_modules/gatsby-source-strapi
 - /home/piotr.roszatycki/Sources/gatsby/strapi-gatsby/node_modules/gatsby/node_modules/gatsby-source-strapi
 - /home/piotr.roszatycki/Sources/gatsby/strapi-gatsby/node_modules/gatsby-source-strapi
 - /home/piotr.roszatycki/Sources/gatsby/node_modules/gatsby-source-strapi
 - /home/piotr.roszatycki/Sources/node_modules/gatsby-source-strapi
 - /home/piotr.roszatycki/node_modules/gatsby-source-strapi
 - /home/node_modules/gatsby-source-strapi
 - /node_modules/gatsby-source-strapi

not finished open and validate gatsby-configs - 0.108s
```

This is because there is no `main` entry point in `packages.json` so it is non-existing `index.js` by default. See: https://docs.npmjs.com/cli/v7/configuring-npm/package-json#main.

Of course everything is fine when I added missing `"main": "lib/index.js"`.
