### PR TITLE
Add support for types defaultData

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,35 @@ plugins: [
 ];
 ```
 
+#### Default data
+It's possible to add default data, if by any chances your API request fails with error code 404.
+
+```javascript
+// In your gatsby-config.js
+plugins: [
+  {
+    resolve: `gatsby-source-strapi`,
+    options: {
+      apiURL: `http://localhost:1337`,
+      collectionTypes: [
+        {
+          name: 'collection-name',
+          api: {
+            qs: {
+              // 'preview' fetches both draft & published content
+              _publicationState: 'preview',
+            }
+          },
+          defaultData: {
+            // default data for collection-name
+          }
+        }
+      ],
+    },
+  },
+],
+```
+
 ## Querying data
 
 You can query Document nodes created from your Strapi API like the following:

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -4,7 +4,7 @@ import { isObject, forEach, set, castArray, startsWith } from 'lodash';
 module.exports = async (entityDefinition, ctx) => {
   const { apiURL, queryLimit, jwtToken, reporter } = ctx;
 
-  const { endpoint, api } = entityDefinition;
+  const { endpoint, api, defaultData } = entityDefinition;
 
   // Define API endpoint.
   let apiBase = `${apiURL}/${endpoint}`;
@@ -27,6 +27,10 @@ module.exports = async (entityDefinition, ctx) => {
     const { data } = await axios(requestOptions);
     return castArray(data).map(clean);
   } catch (error) {
+    if (error.response.status === 404 && defaultData) {
+      reporter.info(`Use Default Data for ${apiBase}`);
+      return castArray(defaultData).map(clean);
+    }
     reporter.panic(`Failed to fetch data from Strapi`, error);
   }
 };

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ const toTypeInfo = (type, { single = false }) => {
       endpoint: type.endpoint || (single ? type.name : pluralize(type.name)),
       name: type.name,
       api: type.api,
+      defaultData: type.defaultData,
     };
   }
 


### PR DESCRIPTION
I'm currently experiencing a phenomenon when a type (collection/single) is created but no data entries are added.

By adding the support for defaultData, gatsby can temporarily bypass the query error and have the site started normally. Entries can be then inserted later.