### PR TITLE
Add getToken option

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,46 @@ plugins: [
 ];
 ```
 
+##### Overwriting the `getToken` method
+
+By default, Strapi's authentication endpoint `/auth/local` is called with the provided `loginData`.  
+If you need to overwrite this mechanism, you can provide a `getToken` function which will be called with `loginData`, `apiURL` and Gatsby's `reporter`.
+
+The resulting `token` string will then be added as `Authorization: Bearer <token>` to Strapi requests as usual.
+
+```javascript
+// In your gatsby-config.js
+plugins: [
+  {
+    resolve: `gatsby-source-strapi`,
+    options: {
+      apiURL: `http://localhost:1337`,
+      collectionTypes: [`collection-name`],
+      loginData: {
+        identifier: '',
+        password: '',
+      },
+      getToken: async ({ loginData, apiURL, reporter }) => {
+        const authenticationActivity = reporter.activityTimer(`Authenticate Strapi User`);
+        authenticationActivity.start();
+
+        try {
+          const token = await yourCustomAuthentication({ loginData });
+          authenticationActivity.end();
+
+          // return the token string
+          return token;
+        } catch (e) {
+          reporter.panic('Strapi authentication error: ' + e);
+        }
+
+        return null;
+      }
+    },
+  },
+];
+```
+
 ## Querying data
 
 You can query Document nodes created from your Strapi API like the following:

--- a/src/index.js
+++ b/src/index.js
@@ -55,11 +55,11 @@ const addDynamicZoneFieldsToSchema = ({ type, items, actions, schema }) => {
 
 exports.sourceNodes = async (
   { store, actions, cache, reporter, getNode, getNodes, createNodeId, createContentDigest, schema },
-  { apiURL = 'http://localhost:1337', loginData = {}, queryLimit = 100, ...options }
+  { apiURL = 'http://localhost:1337', loginData = {}, queryLimit = 100, getToken = authentication, ...options }
 ) => {
   const { createNode, deleteNode, touchNode } = actions;
 
-  const jwtToken = await authentication({ loginData, reporter, apiURL });
+  const jwtToken = await getToken({ loginData, reporter, apiURL });
 
   const ctx = {
     store,


### PR DESCRIPTION
This PR adds a `getToken` option to allow overwriting the default authentication method.

If the option is not provided, the existing `./authentication` import is used.

We're using a different endpoint than the default Strapi one to acquire an access token, so this extra configuration field would be appreciated!