### PR TITLE
fixes `createTypes` deprecated warning

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ const fetchEntities = async (entityDefinition, ctx) => {
 };
 
 const addDynamicZoneFieldsToSchema = ({ type, items, actions, schema }) => {
-  const { createTypes } = actions;
+  const { createSchemaCustomization } = actions;
   // Search for dynamic zones in all items
   const dynamicZoneFields = {};
 
@@ -49,7 +49,7 @@ const addDynamicZoneFieldsToSchema = ({ type, items, actions, schema }) => {
       interfaces: ['Node'],
     });
 
-    createTypes([typeDef]);
+    createSchemaCustomization([typeDef]);
   }
 };
 


### PR DESCRIPTION
fixes Gatsby v4 warning: warn Calling `createTypes` in the `sourceNodes` API is deprecated. Please use: `createSchemaCustomization`.