### PR TITLE
Few changes to support Strapi V4

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,9 @@ plugins: [
 
 #### Authenticated requests
 
-Strapi's [Roles & Permissions plugin](https://strapi.io/documentation/developer-docs/latest/development/plugins/users-permissions.html#concept) allows you to protect your API actions. If you need to access a route that is only available to a logged in user, you can provide your credentials so that this plugin can access to the protected data.
+Strapi's authentication stategies can be based either on Strapi's [Roles & Permissions plugin](https://docs.strapi.io/developer-docs/latest/plugins/users-permissions.html#concept) or on built-in [API token feature](https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/configurations/optional/api-tokens.html#api-tokens). If you need to access a route that is only available to a logged in user, you can provide user credentials or created API token to provide  access to the protected data for plugin.
+
+Warning: API token will take precedence over user credentials if both will be defined in configuration.
 
 ```javascript
 // In your gatsby-config.js
@@ -164,10 +166,13 @@ plugins: [
     options: {
       apiURL: `http://localhost:1337`,
       collectionTypes: [`collection-name`],
+      // if you want use user credentials
       loginData: {
         identifier: '',
         password: '',
       },
+      // if you want use generated API token
+      apiToken: '',
     },
   },
 ];

--- a/src/authentication.js
+++ b/src/authentication.js
@@ -2,10 +2,10 @@ import { has } from 'lodash/fp';
 import axios from 'axios';
 
 module.exports = async ({ loginData, reporter, apiURL }) => {
-  const validIndentifier = has('identifier', loginData) && loginData.identifier.length !== 0;
+  const validIdentifier = has('identifier', loginData) && loginData.identifier.length !== 0;
   const validPassword = has('password', loginData) && loginData.password.length !== 0;
 
-  if (validIndentifier && validPassword) {
+  if (validIdentifier && validPassword) {
     const authenticationActivity = reporter.activityTimer(`Authenticate Strapi User`);
     authenticationActivity.start();
 

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -26,9 +26,8 @@ module.exports = async (entityDefinition, ctx) => {
   );
 
   try {
-    const { data } = await axios(requestOptions);
-    console.log(data);
-    return castArray(data.data).map(clean);
+    const { data: responseData } = await axios(requestOptions);
+    return castArray(responseData.data).map(clean);
   } catch (error) {
     reporter.panic(`Failed to fetch data from Strapi`, error);
   }

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -3,7 +3,7 @@ import qs from 'qs';
 import { isObject, forEach, set, castArray, startsWith } from 'lodash';
 
 module.exports = async (entityDefinition, ctx) => {
-  const { apiURL, queryLimit, jwtToken, reporter } = ctx;
+  const { apiURL, queryLimit, token, reporter } = ctx;
 
   const { endpoint, api } = entityDefinition;
 
@@ -16,7 +16,7 @@ module.exports = async (entityDefinition, ctx) => {
     // Place global params first, so that they can be overriden by api.qs
     paramsSerializer: (params) => qs.stringify(params),
     params: { pagination: { pageSize: queryLimit }, populate: '*', ...api?.qs },
-    headers: addAuthorizationHeader({}, jwtToken),
+    headers: addAuthorizationHeader({}, token),
   };
 
   reporter.info(

--- a/src/index.js
+++ b/src/index.js
@@ -45,19 +45,7 @@ const provideToken = async ({ loginData, apiToken, reporter, apiURL }) => {
 
 const fetchEntities = async (entityDefinition, ctx) => {
   const entities = await fetchData(entityDefinition, ctx);
-  await normalize.downloadMediaFiles(entities, ctx);
-
-  return entities;
-};
-
-const prepareItems = (items) => {
-  // as Strapi v4 delivers all fields in 'attributes' object - flat them to parent level to maintain backwards GraphQL queries compatibility
-  return _.map(items, (item) => {
-    const attributes = item.attributes;
-    delete item.attributes;
-
-    return _.merge(item, attributes);
-  });
+  return await normalize.downloadMediaFiles(entities, ctx);
 };
 
 const addDynamicZoneFieldsToSchema = ({ type, items, actions, schema }) => {
@@ -137,7 +125,7 @@ exports.sourceNodes = async (
 
   // Merge single and collection types and retrieve create nodes
   types.forEach(({ name }, i) => {
-    const items = prepareItems(entities[i]);
+    const items = entities[i];
 
     addDynamicZoneFieldsToSchema({ type: name, items, actions, schema });
 


### PR DESCRIPTION
Hello,

As I'm working on a project which uses newest Strapi version and Gatsby - I decided to make a small contribution to this plugin ;)

I implemented:
- Support for API token
- Change which maintains GraphQL definition compatibility (Strapi V4 provides all fields for entity in `attributes` object what can be problematic in case of upgrade from StrapiV3)

Any feedback highly appreciated :)

Cheers,
Marceli