### PR TITLE
Bump axios version

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "strapi"
   ],
   "dependencies": {
-    "axios": "0.21.1",
+    "axios": "0.24.0",
     "gatsby-node-helpers": "0.3.0",
     "gatsby-source-filesystem": "3.7.1",
     "lodash": "4.17.21",

--- a/src/authentication.js
+++ b/src/authentication.js
@@ -2,10 +2,10 @@ import { has } from 'lodash/fp';
 import axios from 'axios';
 
 module.exports = async ({ loginData, reporter, apiURL }) => {
-  const validIndentifier = has('identifier', loginData) && loginData.identifier.length !== 0;
+  const validIdentifier = has('identifier', loginData) && loginData.identifier.length !== 0;
   const validPassword = has('password', loginData) && loginData.password.length !== 0;
 
-  if (validIndentifier && validPassword) {
+  if (validIdentifier && validPassword) {
     const authenticationActivity = reporter.activityTimer(`Authenticate Strapi User`);
     authenticationActivity.start();
 

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -12,7 +12,7 @@ module.exports = async (entityDefinition, ctx) => {
   const requestOptions = {
     method: 'GET',
     url: apiBase,
-    // Place global params first, so that they can be overriden by api.qs
+    // Place global params first, so that they can be overridden by api.qs
     params: { _limit: queryLimit, ...api?.qs },
     headers: addAuthorizationHeader({}, jwtToken),
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1198,12 +1198,12 @@ atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-axios@0.21.1:
-  version "0.21.1"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
-  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
+axios@0.24.0:
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.24.0.tgz#804e6fa1e4b9c5288501dd9dff56a7a0940d20d6"
+  integrity sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==
   dependencies:
-    follow-redirects "^1.10.0"
+    follow-redirects "^1.14.4"
 
 babel-plugin-dynamic-import-node@^2.3.3:
   version "2.3.3"
@@ -1978,10 +1978,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-follow-redirects@^1.10.0:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.0.tgz#b42e8d93a2a7eea5ed88633676d6597bc8e384db"
-  integrity sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==
+follow-redirects@^1.14.4:
+  version "1.14.6"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.6.tgz#8cfb281bbc035b3c067d6cd975b0f6ade6e855cd"
+  integrity sha512-fhUl5EwSJbbl8AR+uYL2KQDxLkdSjZGR36xy46AO7cOMTrCMON6Sa28FmAnC2tRTDbd/Uuzz3aJBv7EBN7JH8A==
 
 for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## Security issue:
https://github.com/advisories/GHSA-cph5-m8f7-6c5x

## Description:
Upgrade `axios` dependency regarding to the above security issue.

## Changes:
 - Upgrade `axios` to the latest version (**0.24.0**).
 - Fix some typos.

## Comments:
I have a concern of which `axios` version should be upgraded to.
To deal with the security issue, the latest patched version (**0.21.4**) seems enough. 
But after checking the [axios CHANGELOG](https://github.com/axios/axios/blob/master/CHANGELOG.md), there is no breaking changes what affects to axios usage in this project.
So, is it better to use the latest version than the patched version?