### PR TITLE
Create nodes for media type (#285)

### DIFF
--- a/src/normalize.js
+++ b/src/normalize.js
@@ -92,6 +92,34 @@ const prepareTextNode = (text, ctx) => {
 };
 
 /**
+ * Create a child node for media and link the parent node to it
+ * @param {Object} media
+ * @param {Object} ctx
+ * @returns {Object} gatsby node
+ */
+const prepareMediaNode = (media, ctx) => {
+  const { createNodeId, createContentDigest, parentNode } = ctx;
+
+  const nodeType = 'STRAPI__MEDIA';
+  const relationNodeId = createNodeId(`${nodeType}-${media.id}`);
+
+  const node = {
+    ...media,
+    id: relationNodeId,
+    strapi_id: media.id,
+    parent: parentNode.id,
+    children: [],
+    internal: {
+      type: nodeType,
+      content: JSON.stringify(media),
+      contentDigest: createContentDigest(media),
+    },
+  };
+
+  return node;
+};
+
+/**
  * Returns an array of the main node and children nodes to create
  * @param {Object} entity the main entry
  * @param {String} nodeType the name of the main node
@@ -250,6 +278,22 @@ export const createNodes = (entity, ctx, uid) => {
         delete entity[attributeName];
 
         nodes.push(JSONNode);
+      }
+
+      if (type == 'media') {
+        const MediaNode = prepareMediaNode(value, {
+          createContentDigest,
+          createNodeId,
+          parentNode: entryNode,
+        });
+
+        entryNode.children = entryNode.children.concat([MediaNode.id]);
+
+        entity[`${attributeName}___NODE`] = MediaNode.id;
+        // Resolve only the attributeName___NODE and not to both ones
+        delete entity[attributeName];
+
+        nodes.push(MediaNode);
       }
     }
   }

--- a/src/normalize.js
+++ b/src/normalize.js
@@ -281,19 +281,34 @@ export const createNodes = (entity, ctx, uid) => {
       }
 
       if (type == 'media') {
-        const MediaNode = prepareMediaNode(value, {
+        const config = {
           createContentDigest,
           createNodeId,
           parentNode: entryNode,
-        });
+        };
 
-        entryNode.children = entryNode.children.concat([MediaNode.id]);
+        if (Array.isArray(value)) {
+          const mediaNodes = value.map((relation) => prepareMediaNode(relation, config));
+          entity[`${attributeName}___NODE`] = mediaNodes.map(({ id }) => id);
 
-        entity[`${attributeName}___NODE`] = MediaNode.id;
+          mediaNodes.forEach((node) => {
+            if (!getNode(node.id)) {
+              nodes.push(node);
+            }
+          });
+        } else {
+          const mediaNode = prepareMediaNode(value, config);
+
+          entity[`${attributeName}___NODE`] = mediaNode.id;
+
+          const relationNodeToCreate = getNode(mediaNode.id);
+
+          if (!relationNodeToCreate) {
+            nodes.push(mediaNode);
+          }
+        }
         // Resolve only the attributeName___NODE and not to both ones
         delete entity[attributeName];
-
-        nodes.push(MediaNode);
       }
     }
   }


### PR DESCRIPTION
This pull request adds support to extract attributes of type `media` into own nodes.
They are available as `STRAPI__MEDIA` (double undersocre to prevent conflicts with possible collections named media).
This way fragments can be used in gatsby to reduce gql duplication and to keep e.g. the query close to an image component.

Example definition of a fragment in a gatsby component:
```js
export const query = graphql`
    fragment StrapiImage on STRAPI__MEDIA {
        id
        alternativeText
        localFile {
            childImageSharp {
                gatsbyImageData
            }
        }
    }
`;
```

Example usage of the fragment in another gatsby component (assuming there is a collection `page` with a media attribute `image`):
```js
export const query = graphql`
  query($id: String) {
    strapiPage(id: { eq: $id }) {
      title
      locale
      image {
        ...StrapiImage
      }
    }
  }
`
```