### PR TITLE
V4

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "gatsby-node-helpers": "0.3.0",
     "gatsby-source-filesystem": "3.7.1",
     "lodash": "4.17.21",
-    "pluralize": "8.0.0"
+    "pluralize": "8.0.0",
+    "qs": "^6.10.1"
   },
   "devDependencies": {
     "@babel/cli": "7.14.5",

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -9,10 +9,6 @@ module.exports = async (entityDefinition, ctx) => {
 
   // Define API endpoint.
   let apiBase = `${apiURL}/api/${endpoint}`;
-  // const axiosInstance = axios.create({
-  //   paramsSerializer: (params) => qs.stringify(params),
-  //   headers:
-  // })
 
   const requestOptions = {
     method: 'GET',

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import qs from 'qs';
 import { isObject, forEach, set, castArray, startsWith } from 'lodash';
 
 module.exports = async (entityDefinition, ctx) => {
@@ -7,13 +8,18 @@ module.exports = async (entityDefinition, ctx) => {
   const { endpoint, api } = entityDefinition;
 
   // Define API endpoint.
-  let apiBase = `${apiURL}/${endpoint}`;
+  let apiBase = `${apiURL}/api/${endpoint}`;
+  // const axiosInstance = axios.create({
+  //   paramsSerializer: (params) => qs.stringify(params),
+  //   headers:
+  // })
 
   const requestOptions = {
     method: 'GET',
     url: apiBase,
     // Place global params first, so that they can be overriden by api.qs
-    params: { _limit: queryLimit, ...api?.qs },
+    paramsSerializer: (params) => qs.stringify(params),
+    params: { pagination: { pageSize: queryLimit }, populate: '*', ...api?.qs },
     headers: addAuthorizationHeader({}, jwtToken),
   };
 
@@ -25,7 +31,8 @@ module.exports = async (entityDefinition, ctx) => {
 
   try {
     const { data } = await axios(requestOptions);
-    return castArray(data).map(clean);
+    console.log(data);
+    return castArray(data.data).map(clean);
   } catch (error) {
     reporter.panic(`Failed to fetch data from Strapi`, error);
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2090,6 +2090,15 @@ get-intrinsic@^1.0.0:
     has "^1.0.3"
     has-symbols "^1.0.1"
 
+get-intrinsic@^1.0.2:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.1.tgz#15f59f376f855c446963948f0d24cd3637b4abc6"
+  integrity sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==
+  dependencies:
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.1"
+
 get-own-enumerable-property-symbols@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz#b5fde77f22cbe35f390b4e089922c50bce6ef664"
@@ -2867,6 +2876,11 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
+object-inspect@^1.9.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.11.0.tgz#9dceb146cedd4148a0d9e51ab88d34cf509922b1"
+  integrity sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==
+
 object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
@@ -3105,6 +3119,13 @@ punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
+qs@^6.10.1:
+  version "6.10.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.1.tgz#4931482fa8d647a5aab799c5271d2133b981fb6a"
+  integrity sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==
+  dependencies:
+    side-channel "^1.0.4"
 
 readable-stream@^2.0.2:
   version "2.3.7"
@@ -3367,6 +3388,15 @@ shebang-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
+
+side-channel@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
+  integrity sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==
+  dependencies:
+    call-bind "^1.0.0"
+    get-intrinsic "^1.0.2"
+    object-inspect "^1.9.0"
 
 signal-exit@^3.0.2:
   version "3.0.3"


### PR DESCRIPTION
Im trying to use accessToken in the strapi config as per the doc:

require('dotenv').config({
  path: `.env.${process.env.NODE_ENV}`,
});

const strapiConfig = {
  apiURL: process.env.STRAPI_API_URL,
  accessToken: process.env.STRAPI_TOKEN, 
  collectionTypes: ['article', 'company', 'author'],
  singleTypes: [],
};

module.exports = {
  plugins: [
    {
      resolve: `gatsby-source-strapi`,
      options: strapiConfig,
    },
  ],
};
however, the plugin is completely ignoring the accessToken. So i checked the source code of the plugin. and found out that in lib/index.js it tries to get an access token using "identifier/password" rest call. and there is NO consideration if the JWT already passed in the options. the code is

const jwtToken = await (0, _authentication.default)({ loginData, reporter, apiURL });

if there is no loginData in the options, authentication will return JjwtToken as null.

so in order to accessToken option work, i had to modify the lib/index.js as follows:

...
...
{
  apiURL = 'http://localhost:1337',
  loginData = {},
  queryLimit = 100,
  accessToken = null, // <--- added accessToken as const here
  ...options
})
....
....
  const jwtToken = accessToken || await (0, _authentication.default)({   // <---- if accessToken is in the options then use it, else fall to the login method
    loginData,
    reporter,
    apiURL
  });
...
...