### PR TITLE
Support undefined singleTypes in strapi config

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -26,6 +26,14 @@ exports.sourceNodes = async (
   },
   pluginOptions
 ) => {
+  // Cast singleTypes and collectionTypes to empty arrays if they're undefined
+  if (pluginOptions.singleTypes == null) {
+    pluginOptions.singleTypes = [];
+  }
+  if (pluginOptions.collectionTypes == null) {
+    pluginOptions.collectionTypes = [];
+  }
+
   const { schemas } = await fetchStrapiContentTypes(pluginOptions);
 
   const { deleteNode, touchNode } = actions;

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -26,11 +26,11 @@ exports.sourceNodes = async (
   },
   pluginOptions
 ) => {
-  // Cast singleTypes and collectionTypes to empty arrays if they're undefined
-  if (pluginOptions.singleTypes == null) {
+  // Cast singleTypes and collectionTypes to empty arrays if they're not defined
+  if (!Array.isArray(pluginOptions.singleTypes)) {
     pluginOptions.singleTypes = [];
   }
-  if (pluginOptions.collectionTypes == null) {
+  if (!Array.isArray(pluginOptions.collectionTypes)) {
     pluginOptions.collectionTypes = [];
   }
 


### PR DESCRIPTION
Fixes #303

Currently, if the user has no single types, he still has to add `singleTypes: []` to his config. If he doesn't, the app will crash.

This PR changes that behavior by making the singleTypes and collectionTypes optional. It will also make it easier to migrate from the source plugin v1 to v2, since this is how it already worked before.
