### PR TITLE
Fix i18n support

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ You can use the following query:
 
 #### Internationalization
 
-Content types in Strapi can be localized with the [i18n plugin](https://docs.strapi.io/developer-docs/latest/plugins/i18n.html). But by default, gatsby-source-strapi will only fetch data in the default locale of your Strapi app. To specify which locale should be fetched, an `i18n` object can be provided in the content type's `pluginOptions`. Use the all value to get all available locales on a collection type.
+Content types in Strapi can be localized with the [i18n plugin](https://docs.strapi.io/developer-docs/latest/plugins/i18n.html). But by default, gatsby-source-strapi will only fetch data in the default locale of your Strapi app. To specify which locale should be fetched, an `i18n` object can be provided in the content type's `pluginOptions`. You can also set the locale to `all` to get all available localizations of a content type:
 
 ```javascript
 const strapiConfig = {
@@ -321,20 +321,20 @@ const strapiConfig = {
 };
 ```
 
-Then use the following query to fetch a localized content:
+Then use the one of the following queries to fetch a localized content type:
 
 ```graphql
 {
   # Get content in all available localizations
   allStrapiGlobal {
     nodes {
-      id
+      locale
     }
   }
 
   # Get a single type in a specific locale
   strapiGlobal(locale: {eq: "fr"}) {
-    id
+    locale
   }
 
   # Get a collection type in a specific locale

--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@ Source plugin for pulling documents into Gatsby from a Strapi API.
 <summary><strong>Table of contents</strong></summary>
 
 - [gatsby-source-strapi](#gatsby-source-strapi)
-  - [Install](#installing-the-plugin)
+  - [Installing the plugin](#installing-the-plugin)
+    - [Using yarn](#using-yarn)
+    - [Or using NPM](#or-using-npm)
+  - [Setting up the plugin](#setting-up-the-plugin)
     - [Basic usage](#basic-usage)
     - [Advanced usage](#advanced-usage)
       - [Deep queries populate](#deep-queries-populate)
@@ -17,7 +20,14 @@ Source plugin for pulling documents into Gatsby from a Strapi API.
       - [Rich text field](#rich-text-field)
       - [Components](#components)
       - [Dynamic zones](#dynamic-zones)
+      - [Internationalization](#internationalization)
   - [Gatsby cloud and preview environment setup](#gatsby-cloud-and-preview-environment-setup)
+    - [Setup](#setup)
+    - [Enabling Content Sync](#enabling-content-sync)
+      - [Installing the @strapi/plugin-gatsby-preview](#installing-the-strapiplugin-gatsby-preview)
+        - [Using yarn](#using-yarn-1)
+        - [Using npm](#using-npm)
+      - [Configurations](#configurations)
   - [Restrictions and limitations](#restrictions-and-limitations)
 
 </details>
@@ -42,7 +52,7 @@ You can enable and configure this plugin in your `gatsby-config.js` file.
 
 ### Basic usage
 
-First, you need to configure the `STRAPI_API_URL` and the `STRAPI_TOKEN` environment variables. We recommend using [`dotenv`][https://github.com/motdotla/dotenv] to expose these variables.
+First, you need to configure the `STRAPI_API_URL` and the `STRAPI_TOKEN` environment variables. We recommend using [`dotenv`](https://github.com/motdotla/dotenv) to expose these variables.
 
 Make sure to create a full-access [API token](https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/configurations/optional/api-tokens.html) in Strapi.
 
@@ -248,7 +258,7 @@ To query a specific component use the following query:
 
 #### Dynamic zones
 
-To query dynamic zones, , write a query using [inline GraphQL fragments](https://graphql.org/learn/queries/#inline-fragments).
+To query dynamic zones, write a query using [inline GraphQL fragments](https://graphql.org/learn/queries/#inline-fragments).
 
 You can use the following query:
 
@@ -275,6 +285,62 @@ You can use the following query:
           strapi_component
         }
       }
+    }
+  }
+}
+```
+
+#### Internationalization
+
+Content types in Strapi can be localized with the [i18n plugin](https://docs.strapi.io/developer-docs/latest/plugins/i18n.html). But by default, gatsby-source-strapi will only fetch data in the default locale of your Strapi app. To specify which locale should be fetched, an `i18n` object can be provided in the content type's `pluginOptions`. Use the all value to get all available locales on a collection type.
+
+```javascript
+const strapiConfig = {
+  // ...
+  collectionTypes: [
+    {
+      singularName: 'article',
+      pluginOptions: {
+        i18n: {
+          locale: 'fr', // Only fetch a specific locale
+        },
+      },
+    },
+  ],
+  singleTypes: [
+    {
+      singularName: 'global',
+      pluginOptions: {
+        i18n: {
+          locale: 'all', // Fetch all localizations
+        },
+      },
+    },
+  ],
+  // ...
+};
+```
+
+Then use the following query to fetch a localized content:
+
+```graphql
+{
+  # Get content in all available localizations
+  allStrapiGlobal {
+    nodes {
+      id
+    }
+  }
+
+  # Get a single type in a specific locale
+  strapiGlobal(locale: {eq: "fr"}) {
+    id
+  }
+
+  # Get a collection type in a specific locale
+  allStrapiArticle(filter: {locale: {eq: "fr"}}) {
+    nodes {
+      locale
     }
   }
 }

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -57,7 +57,6 @@ const fetchEntity = async ({ endpoint, queryParams, uid, pluginOptions }, ctx) =
             },
           },
         });
-        // otherLocales = response.data.attributes.localizations.data.map(localization => localization.attributes.locale)
         response.data.attributes.localizations.data.forEach((localization) =>
           otherLocales.push(localization.attributes.locale)
         );

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -28,9 +28,6 @@ const fetchEntity = async ({ endpoint, queryParams, uid, pluginOptions }, ctx) =
   const { strapiConfig, reporter } = ctx;
   const axiosInstance = createInstance(strapiConfig);
 
-  // Ignore queryParams locale in favor of pluginOptions
-  delete queryParams.locale;
-
   const opts = {
     method: 'GET',
     url: endpoint,
@@ -44,7 +41,11 @@ const fetchEntity = async ({ endpoint, queryParams, uid, pluginOptions }, ctx) =
     // Handle internationalization
     const locale = pluginOptions?.i18n?.locale;
     const otherLocales = [];
+
     if (locale) {
+      // Ignore queryParams locale in favor of pluginOptions
+      delete queryParams.locale;
+
       if (locale === 'all') {
         // Get all available locales
         const { data: response } = await axiosInstance({
@@ -62,7 +63,7 @@ const fetchEntity = async ({ endpoint, queryParams, uid, pluginOptions }, ctx) =
         );
       } else {
         // Only one locale
-        opts.params.locale = locale;
+        queryParams.locale = locale;
       }
     }
 
@@ -100,9 +101,6 @@ const fetchEntities = async ({ endpoint, queryParams, uid, pluginOptions }, ctx)
   const { strapiConfig, reporter } = ctx;
   const axiosInstance = createInstance(strapiConfig);
 
-  // Ignore queryParams locale in favor of pluginOptions
-  delete queryParams.locale;
-
   const opts = {
     method: 'GET',
     url: endpoint,
@@ -112,7 +110,8 @@ const fetchEntities = async ({ endpoint, queryParams, uid, pluginOptions }, ctx)
 
   // Use locale from pluginOptions if it's defined
   if (pluginOptions?.i18n?.locale) {
-    opts.params.locale = pluginOptions.i18n.locale;
+    delete queryParams.locale;
+    queryParams.locale = pluginOptions.i18n.locale;
   }
 
   try {

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -24,22 +24,22 @@ exports.sourceNodes = async (
     getNodes,
     getNode,
   },
-  pluginOptions
+  strapiConfig
 ) => {
   // Cast singleTypes and collectionTypes to empty arrays if they're not defined
-  if (!Array.isArray(pluginOptions.singleTypes)) {
-    pluginOptions.singleTypes = [];
+  if (!Array.isArray(strapiConfig.singleTypes)) {
+    strapiConfig.singleTypes = [];
   }
-  if (!Array.isArray(pluginOptions.collectionTypes)) {
-    pluginOptions.collectionTypes = [];
+  if (!Array.isArray(strapiConfig.collectionTypes)) {
+    strapiConfig.collectionTypes = [];
   }
 
-  const { schemas } = await fetchStrapiContentTypes(pluginOptions);
+  const { schemas } = await fetchStrapiContentTypes(strapiConfig);
 
   const { deleteNode, touchNode } = actions;
 
   const ctx = {
-    strapiConfig: pluginOptions,
+    strapiConfig,
     actions,
     schemas,
     createContentDigest,
@@ -58,7 +58,7 @@ exports.sourceNodes = async (
 
   existingNodes.forEach((n) => touchNode(n));
 
-  const endpoints = getEndpoints(pluginOptions, schemas);
+  const endpoints = getEndpoints(strapiConfig, schemas);
 
   const lastFetched = await cache.get(LAST_FETCHED_KEY);
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -99,7 +99,7 @@ const getEndpoints = ({ collectionTypes, singleTypes }, schemas) => {
     )
     .map(({ schema: { kind, singularName, pluralName }, uid }) => {
       const options = types.find((config) => config.singularName === singularName);
-      const { queryParams, queryLimit } = options;
+      const { queryParams, queryLimit, pluginOptions } = options;
 
       if (kind === 'singleType') {
         return {
@@ -110,6 +110,7 @@ const getEndpoints = ({ collectionTypes, singleTypes }, schemas) => {
           queryParams: queryParams || {
             populate: '*',
           },
+          pluginOptions,
         };
       }
 
@@ -127,6 +128,7 @@ const getEndpoints = ({ collectionTypes, singleTypes }, schemas) => {
           },
           populate: queryParams?.populate || '*',
         },
+        pluginOptions,
       };
     });
 


### PR DESCRIPTION
## What this does:

- Fix single types internationalization (fixes #291)
- Introduce a new pluginOptions object in a content type's config object. Right now it's only to add an i18n key, but the goal is to be able to expand on it later, so that it eventually replaces queryParams altogether

First, I check if a content type has `pluginOptions.i18n.locale` defined. If it does, for collection types I set that value as the `locale` query param. For single types types, I do the same, except if the locale is "all", because it's [not supported](https://github.com/strapi/strapi/issues/12638) for single types in Strapi.

So in this case, I populate the localizations key in order to get the list of all available locales for a single type. Then, I make a dedicated request for each of these locales, so that they have the same response (level of population etc.) as the base request. I then merge all the localizations together with the default one.

## How to test it:

* Create a Strapi app with the corporate template (because it has localized content)
* Create a Gatsby app with this config:

```js
module.exports = {
  plugins: [
    {
      resolve: `gatsby-source-strapi`,
      options: {
        apiURL: "http://localhost:1337",
        accessToken: process.env.API_TOKEN,
        collectionTypes: [
          {
            singularName: 'page',
            pluginOptions: {
              i18n: {
                locale: 'fr' // try changing this
              }
            }
          }
        ],
        singleTypes: [
          {
            singularName: 'global',
            pluginOptions: {
              i18n: {
                locale: 'all', // try changing this
              },
            },
          }
        ],
      },
    },
  ],
}
```

* Open GraphiQL and query the different localizations of your content types