### PR TITLE
Add configuration option to skip image processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,19 @@ To query your asset use the following query:
 }
 ```
 
+If you do not want this plugin to download your media (images, videos, and file attachments), you can use the `skipMediaProcessing` configuration option
+
+
+**Path:** `./gatsby.config.js`
+
+```javascript
+const strapiConfig = {
+  // ...
+  skipMediaProcessing: true
+  // ...
+};
+```
+
 #### Rich text field
 
 Rich text fields can now be processed using the [`gatsby-transformer-remark`](https://www.gatsbyjs.com/plugins/gatsby-transformer-remark/https://www.gatsbyjs.com/plugins/gatsby-transformer-remark/) plugin.

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ To query your asset use the following query:
 }
 ```
 
-If you do not want this plugin to download your media (images, videos, and file attachments), you can use the `skipMediaProcessing` configuration option
+If you do not want this plugin to download your media (images, videos, and file attachments), you can use the `skipFileDownloads` configuration option
 
 
 **Path:** `./gatsby.config.js`
@@ -195,7 +195,7 @@ If you do not want this plugin to download your media (images, videos, and file 
 ```javascript
 const strapiConfig = {
   // ...
-  skipMediaProcessing: true
+  skipFileDownloads: true
   // ...
 };
 ```

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -135,7 +135,7 @@ exports.sourceNodes = async (
   for (let i = 0; i < endpoints.length; i++) {
     const { uid } = endpoints[i];
 
-    if (!strapiConfig.skipMediaProcessing) {
+    if (!strapiConfig.skipFileDownloads) {
       await downloadMediaFiles(data[i], ctx, uid);
     }
 

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -135,7 +135,9 @@ exports.sourceNodes = async (
   for (let i = 0; i < endpoints.length; i++) {
     const { uid } = endpoints[i];
 
-    await downloadMediaFiles(data[i], ctx, uid);
+    if (!strapiConfig.skipMediaProcessing) {
+      await downloadMediaFiles(data[i], ctx, uid);
+    }
 
     for (let entity of data[i]) {
       const nodes = createNodes(entity, ctx, uid);


### PR DESCRIPTION
In some cases, developers may want to skip image processing entirely. This may be useful for a site that is using an image CDN such as cloudinary: the CDN provides transformations, so we don't need to use Gatsby's transformation layer. This PR adds such an option.

Relevant issues:  #305